### PR TITLE
Update docs to reference shadcn@latest CLI and Supabase integration

### DIFF
--- a/documentacao/BACKLOG_TASKLISTS.md
+++ b/documentacao/BACKLOG_TASKLISTS.md
@@ -2,15 +2,15 @@
 
 ---
 
-## [URGENTE] Adotar shadcn-ui no projeto  
+## [URGENTE] Adotar shadcn@latest no projeto  
 **Depende de:** nada  
 **Descrição:**  
-Padronizar e acelerar a criação de componentes de interface usando a biblioteca shadcn-ui.
+Padronizar e acelerar a criação de componentes de interface usando a CLI shadcn@latest.
 
 **Tasklist:**
-- [ ] Instalar shadcn-ui e dependências
+- [ ] Instalar shadcn@latest e dependências (`npx shadcn@latest init`)
 - [ ] Configurar integração com Tailwind
-- [ ] Criar primeiro componente usando shadcn-ui
+- [ ] Criar primeiro componente usando shadcn@latest (`npx shadcn@latest add <componente>`)
 - [ ] Documentar padrão de uso para o time
 - [ ] Migrar gradualmente componentes existentes
 
@@ -128,7 +128,7 @@ Coletar e exibir depoimentos de clientes e parceiros.
 ---
 
 ## [BAIXA] Animações e interatividade  
-**Depende de:** UI padronizada (shadcn-ui)  
+**Depende de:** UI padronizada (shadcn@latest)  
 **Descrição:**  
 Melhorar a experiência visual do site com animações e microinterações.
 

--- a/documentacao/PAUTA_REUNIAO_TI_AVANCE.md
+++ b/documentacao/PAUTA_REUNIAO_TI_AVANCE.md
@@ -72,9 +72,9 @@ O desenvolvimento será organizado em sprints semanais, com dedicação de 1-2h/
 ### Sprint 1 — Kickoff e Fundamentos
 - **Objetivo:** Configuração de base, padronização de UI, início do analytics e integração inicial.
 - **Tarefas:**
-  - [Pedro Mezadre, Myke Matos] Instalar e configurar shadcn-ui; criar primeiro componente padrão; documentar padrão de uso
+- [Pedro Mezadre, Myke Matos] Instalar e configurar shadcn@latest (`npx shadcn@latest init`); criar primeiro componente padrão (`npx shadcn@latest add <componente>`); documentar padrão de uso
   - [Pedro Henrique] Instalar e configurar PostHog; criar conta/workspace; instrumentar páginas principais
-  - [João Guilherme] Apoiar documentação dos padrões (shadcn-ui, PostHog); checklist de setup do projeto
+  - [João Guilherme] Apoiar documentação dos padrões (shadcn-ui, Supabase); checklist de setup do projeto
   - [Myke Matos] Revisão técnica, desbloqueio de impedimentos, apoio na configuração e no front end
 
 ### Sprint 2 — Integração de Dados e Estrutura MVP
@@ -117,7 +117,7 @@ O desenvolvimento será organizado em sprints semanais, com dedicação de 1-2h/
    - Testes e boas práticas — configurados
 
 2. **Adoção de novas ferramentas**
-   - Proposta de inclusão do shadcn-ui (biblioteca de componentes UI) para acelerar e padronizar a criação de interfaces.
+   - Proposta de inclusão do shadcn@latest (CLI de componentes UI) para acelerar e padronizar a criação de interfaces.
    - Proposta de inclusão do PostHog (analytics) para monitoramento de uso, métricas de produto e tomada de decisão baseada em dados.
    - Benefícios: agilidade, consistência visual, acessibilidade, instrumentação de analytics, decisões baseadas em dados.
    - Próximos passos: aprovar inclusão, definir responsáveis pela configuração inicial, planejar padronização dos novos componentes e instrumentação básica de analytics.
@@ -156,7 +156,7 @@ O desenvolvimento será organizado em sprints semanais, com dedicação de 1-2h/
 - Atualizar o Trello/board com microtarefas e responsáveis
 - Realizar checkpoints de progresso no grupo (WhatsApp/Discord)
 - Reportar bloqueios imediatamente ao gestor (Myke)
-- Manter documentação e convenções atualizadas
+- Manter documentação e convenções atualizadas (incluindo uso do shadcn@latest)
 - Preparar demonstração do MVP para a próxima reunião
 
 ---

--- a/documentacao/PLANO_SPRINTS.md
+++ b/documentacao/PLANO_SPRINTS.md
@@ -14,13 +14,13 @@
 Configuração de base, padronização de UI, início do analytics e integração inicial.
 
 **Tarefas:**
-- [Pedro Mezadre, Myke Matos] Instalar e configurar shadcn-ui; criar primeiro componente padrão; documentar padrão de uso
-- [Pedro Henrique] Instalar e configurar PostHog; criar conta/workspace; instrumentar páginas principais
-- [João Guilherme] Apoiar documentação dos padrões (shadcn-ui, PostHog); checklist de setup do projeto
+- [Pedro Mezadre, Myke Matos] Instalar e configurar shadcn@latest; criar primeiro componente padrão; documentar padrão de uso
+- [Pedro Henrique] Instalar e configurar Supabase; Adicionar funcionalidades internas para membros autenticados (documentos, recursos, etc).
+- [João Guilherme] Apoiar documentação dos padrões (shadcn, Supabase); checklist de setup do projeto
 - [Myke Matos] Revisão técnica, desbloqueio de impedimentos, apoio na configuração e no front end
 
 **Critérios de conclusão:**
-- shadcn-ui e PostHog funcionando no projeto
+- shadcn@latest e Supabase funcionando no projeto
 - Documentação básica dos padrões criada
 - Time alinhado com o fluxo de trabalho
 
@@ -33,13 +33,13 @@ Exibir dados reais de setores, membros e serviços; estruturar páginas principa
 
 **Tarefas:**
 - [Pedro Henrique] Mapear endpoints no Supabase; implementar fetch de dados; tratar loading/erros
-- [Pedro Mezadre, Myke Matos] Criar páginas: inicial, setores, membros, serviços; usar componentes shadcn-ui
+- [Pedro Mezadre, Myke Matos] Criar páginas: inicial, setores, membros, serviços; usar componentes shadcn@latest
 - [João Guilherme] Validar dados exibidos; apoiar testes e revisão de conteúdo
 - [Myke Matos] Revisão técnica, apoio em integrações, acompanhamento do progresso e no front end
 
 **Critérios de conclusão:**
 - Dados reais exibidos nas páginas principais
-- Layout padronizado com shadcn-ui
+- Layout padronizado com shadcn@latest
 - Erros e estados de loading tratados
 
 ---

--- a/documentacao/STATUS_DESENVOLVIMENTO.md
+++ b/documentacao/STATUS_DESENVOLVIMENTO.md
@@ -3,7 +3,7 @@
 ## Estrutura do Projeto
 
 - **Stack:** Next.js, TypeScript, Tailwind, Supabase
-- **UI:** shadcn-ui adotado para padronização e agilidade na criação de componentes
+- **UI:** shadcn@latest (CLI) adotado para padronização e agilidade na criação de componentes
 - **Analytics:** PostHog adotado para monitoramento de uso e métricas de produto
 - **Testes:** Jest configurado, pasta de testes presente
 - **Lint/Format:** ESLint e Prettier configurados
@@ -12,9 +12,9 @@
 
 ### Novas ferramentas adotadas
 
-- **shadcn-ui:** Biblioteca moderna de componentes React/Next.js, baseada em Radix UI e TailwindCSS.  
+- **shadcn@latest:** CLI moderna para geração de componentes React/Next.js, baseada em Radix UI e TailwindCSS.  
   - *Benefícios:* Agilidade no desenvolvimento, consistência visual, acessibilidade, fácil customização.
-  - *Próximos passos:* Padronizar novos componentes e migrar gradualmente a UI para shadcn-ui.
+  - *Próximos passos:* Padronizar novos componentes e migrar gradualmente a UI utilizando a CLI shadcn@latest.
 
 - **PostHog:** Plataforma open source de analytics e product analytics.
   - *Benefícios:* Monitoramento de uso, métricas de produto, eventos customizados, privacidade (LGPD), decisões baseadas em dados.
@@ -82,4 +82,6 @@ O projeto já possui:
 
 ---
 
-*Documento gerado automaticamente para acompanhamento do progresso do desenvolvimento.*
+**Changelog 24/05**
+
+Adicionado documentaçao do projeto, sprints, tutoriais e backlog na raiz do projeto.


### PR DESCRIPTION
Replace mentions of shadcn-ui with shadcn@latest CLI in backlog, meeting agenda, and sprint plan documents to reflect updated installation and usage practices. Update task assignments to include Supabase setup and clarify documentation responsibilities. These changes ensure documentation aligns with current project tooling and onboarding processes.